### PR TITLE
Support ID Token generation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,7 @@ jobs:
       with:
         workload_identity_provider: 'projects/469401941463/locations/global/workloadIdentityPools/github-actions/providers/github-oidc-auth-google-cloud'
         service_account: 'github-secret-accessor@actions-oidc-test.iam.gserviceaccount.com'
+        id_token_audience: 'foo'
 
     - name: 'npm install'
       run: 'npm install'

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ jobs:
     seconds. This must be specified as the number of seconds with a trailing "s"
     (e.g. 30s). The default value is 1 hour (3600s).
 
+-   `id_token_audience`: (Optional) The audience for the generated ID Token.
+
 ## Outputs
 
 -   `access_token`: The authenticated Google Cloud access token for calling
@@ -89,6 +91,9 @@ jobs:
 
 -   `expiration`: The RFC3339 UTC "Zulu" format timestamp when the token
     expires.
+
+-   `id_token`: The authenticated Google Cloud ID token. This token is only
+    generated when `id_token_audience` input parameter was provided.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ jobs:
     expires.
 
 -   `id_token`: The authenticated Google Cloud ID token. This token is only
-    generated when `id_token_audience` input parameter was provided.
+    generated when `id_token_audience` input parameter is provided.
 
 ## Setup
 

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,11 @@ inputs:
       specified as the number of seconds with a trailing "s" (e.g. 30s).
     default: '3600s'
     required: false
+  id_token_audience:
+    description: |-
+      The audience for the generated Google Cloud ID Token.
+    default: ''
+    required: false
 
 outputs:
   access_token:
@@ -58,6 +63,10 @@ outputs:
   expiration:
     description: |-
       The expiration timestamp for the access token.
+  id_token:
+    description: |-
+      The Google Cloud ID token. This token is only generated when
+      `id_token_audience` input parameter was provided.
 
 branding:
   icon: 'lock'

--- a/dist/index.js
+++ b/dist/index.js
@@ -253,7 +253,7 @@ function run() {
             core.setOutput('access_token', accessToken);
             core.setOutput('expiration', expiration);
             // Exchange the Google Federated Token for an ID token.
-            if (idTokenAudience != null) {
+            if (idTokenAudience != '') {
                 const { token } = yield client_1.Client.googleIDToken({
                     token: googleFederatedToken,
                     serviceAccount: serviceAccount,

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,7 +74,7 @@ async function run(): Promise<void> {
     core.setOutput('expiration', expiration);
 
     // Exchange the Google Federated Token for an ID token.
-    if (idTokenAudience != null) {
+    if (idTokenAudience != '') {
       const { token } = await Client.googleIDToken({
         token: googleFederatedToken,
         serviceAccount: serviceAccount,

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,7 @@ async function run(): Promise<void> {
     const audience = core.getInput('audience');
     const delegates = explodeStrings(core.getInput('delegates'));
     const lifetime = core.getInput('lifetime');
+    const idTokenAudience = core.getInput('id_token_audience');
 
     // Extract the GitHub Actions OIDC token.
     const requestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
@@ -71,6 +72,18 @@ async function run(): Promise<void> {
     core.setSecret(accessToken);
     core.setOutput('access_token', accessToken);
     core.setOutput('expiration', expiration);
+
+    // Exchange the Google Federated Token for an ID token.
+    if (idTokenAudience != null) {
+      const { token } = await Client.googleIDToken({
+        token: googleFederatedToken,
+        serviceAccount: serviceAccount,
+        delegates: delegates,
+        audience: idTokenAudience,
+      });
+      core.setSecret(token);
+      core.setOutput('id_token', token);
+    }
   } catch (err) {
     core.setFailed(`Action failed with error: ${err}`);
   }


### PR DESCRIPTION
## What
This PR adds support for ID Token generation.

## Motivation

I think there are some use cases where we want to use impersonated service account's ID token to access IAM-protected resources (e.g. accessing Cloud Run services, IAP-protected endpoints, etc) from GitHub Actions.

## Design Considerations

* Made `id_token_audience` as an optional parameter since not all users want to mint an ID token.
* Fixed `includeEmail` parameter for [generateIdToken](https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateIdToken) method with always `true` since I guess most users assume that by default. Probably we can add `id_token_includ_email` boolean parameter if users want to control that.